### PR TITLE
Fix help messages

### DIFF
--- a/lib/lita/handlers/against_humanity.rb
+++ b/lib/lita/handlers/against_humanity.rb
@@ -749,8 +749,8 @@ module Lita
         "Zeus's sexual appetites."
       ]
 
-      route /humanity choice/, :choice, command: true, help: { "lita humanity choice" => "Lita can only take you some of the way" }
-      route "humanity", :go, command: true, help: { "lita humanity" => "Lita will play a random pair of cards from Cards Against Humanity" }
+      route /humanity choice/, :choice, command: true, help: { "humanity choice" => "Lita can only take you some of the way" }
+      route "humanity", :go, command: true, help: { "humanity" => "Lita will play a random pair of cards from Cards Against Humanity" }
 
       def go(response)
         response.reply(BLACK_CARDS.sample)


### PR DESCRIPTION
The help message default is to not include `lita` at the beginning of the message. This PR just fixes that :smile: 

<img width="539" alt="screen shot 2015-12-11 at 23 20 30" src="https://cloud.githubusercontent.com/assets/670623/11758002/e833a0e0-a05d-11e5-9adf-bfea0d1f4c70.png">
